### PR TITLE
feat: added positino monitor and store

### DIFF
--- a/config.json
+++ b/config.json
@@ -44,5 +44,33 @@
     "chain_id": 137,
     "domain_name": "Polymarket CTF Exchange",
     "domain_version": "1"
+  },
+  "filters": {
+    "_comment_mode": "Strict allowlist: when any *_allow list is non-empty, only matching markets are copied. Block lists always win.",
+    "slug_allow": [],
+    "slug_block": [],
+    "categories_allow": ["Politics", "Sports", "Crypto"],
+    "categories_block": ["Memes"],
+    "tags_allow": [],
+    "tags_block": ["satire"],
+    "per_category_max_open_usd": {
+      "Politics": 500.0,
+      "Sports": 300.0,
+      "Crypto": 400.0
+    },
+    "per_tag_max_open_usd": {}
+  },
+  "tp_sl": {
+    "enabled": true,
+    "default_take_profit_pct": 50.0,
+    "default_stop_loss_pct": 30.0,
+    "per_category_tp_pct": {
+      "Politics": 40.0,
+      "Sports": 30.0
+    },
+    "per_category_sl_pct": {
+      "Politics": 25.0
+    },
+    "poll_interval_secs": 15
   }
 }

--- a/src/bot/copy_trading.rs
+++ b/src/bot/copy_trading.rs
@@ -7,24 +7,38 @@
 //!    watched whale address packed as topic-2 (maker). Server-side filtering
 //!    means the bot is woken only when the whale actually transacts.
 //! 2. **Parse**: decode raw logs into [`WhaleTrade`] via [`service::parse`].
-//! 3. **Sizing**: apply the configured copy strategy ([`service::strategy`]).
-//! 4. **Risk**: fast in-memory check, optional book/depth check
+//! 3. **Eligibility**: resolve market metadata via Gamma, then check against
+//!    the operator's allow/block lists ([`service::eligibility`]).
+//! 4. **Sizing**: apply the configured copy strategy ([`service::strategy`]).
+//! 5. **Exposure caps**: per-category and per-tag open-USD limits enforced
+//!    via [`service::position_store`].
+//! 6. **Risk**: fast in-memory check, optional book/depth check
 //!    ([`service::risk_guard`]).
-//! 5. **Execute**: build EIP-712 signed CTF order, post via L2 auth
+//! 7. **Execute**: build EIP-712 signed CTF order, post via L2 auth
 //!    ([`service::clob`], [`service::order_executor`]).
+//! 8. **TP/SL**: background monitor polls midprice for every open position
+//!    and submits an exit FAK when P&L crosses the configured thresholds
+//!    ([`service::position_monitor`]).
 //!
 //! Safety: `enable_trading=false` OR `mock_trading=true` keeps the executor
-//! in dry-run mode — the full pipeline runs but signed orders are logged, not
-//! submitted.
+//! in dry-run mode — the full pipeline runs but signed orders are logged,
+//! not submitted. Dry-run also records positions locally so the TP/SL
+//! monitor exercises against real midprices.
 
 use crate::config::AppConfig;
 use crate::service::{
+    clob::ClobClient,
+    market_cache::MarketCache,
+    midprice::{ClobMidpriceSource, MidpriceSource},
     onchain::{spawn_subscription, LogFilter, RawLog},
     order_executor::{ExecutionOutcome, OrderExecutor},
     parse::{decode_whale_trade, order_filled_topic},
+    position_monitor,
+    position_store::PositionStore,
     risk_guard::RiskGuard,
 };
 use anyhow::{anyhow, Result};
+use reqwest::Client;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -43,24 +57,65 @@ pub async fn run(cfg: AppConfig) -> Result<()> {
         whale = %whale,
         enable_trading = cfg.bot.enable_trading,
         mock_trading = cfg.bot.mock_trading,
+        strict_allowlist = cfg.filters.is_strict(),
+        tp_sl_enabled = cfg.tp_sl.enabled,
         "starting copy-trading bot"
     );
 
+    let http = Client::builder()
+        .user_agent("polymarket-toolkits/0.1")
+        .build()?;
     let risk = RiskGuard::new(cfg.risk.clone());
-    let executor = OrderExecutor::new(cfg.clone(), Arc::clone(&risk))?;
+    let markets = MarketCache::new(http.clone(), cfg.site.gamma_api_base.clone());
+    let positions = PositionStore::new();
+
+    let executor = OrderExecutor::new(
+        cfg.clone(),
+        Arc::clone(&risk),
+        Arc::clone(&markets),
+        Arc::clone(&positions),
+    )?;
+
+    // TP/SL monitor — only spawn if we have a CLOB client (cfg permitted it).
+    if cfg.tp_sl.enabled {
+        if let Some(clob) = executor.clob() {
+            let midprice: Arc<dyn MidpriceSource> = Arc::new(ClobMidpriceSource::new(
+                http.clone(),
+                cfg.site.clob_api_base.clone(),
+            ));
+            let live = cfg.live_trading_allowed();
+            position_monitor::spawn(
+                cfg.tp_sl.clone(),
+                Arc::clone(&positions),
+                clob,
+                midprice,
+                live,
+                cfg.trading.price_buffer,
+                cfg.trading.order_expiration_secs,
+            );
+            info!(
+                poll_interval_secs = cfg.tp_sl.poll_interval_secs,
+                "TP/SL monitor spawned"
+            );
+        } else {
+            warn!(
+                "TP/SL enabled but no CLOB client (missing credentials?) — \
+                 entries will still record positions, but exits won't fire"
+            );
+        }
+    }
 
     let filter = build_filter(&cfg, &whale)?;
     let (tx, mut rx) = mpsc::channel::<RawLog>(LOG_CHANNEL_CAPACITY);
     let _sub = spawn_subscription(cfg.site.polygon_ws_url.clone(), filter, tx);
 
-    let mut shutdown =
-        Box::pin(tokio::signal::ctrl_c());
+    let mut shutdown = Box::pin(tokio::signal::ctrl_c());
 
     loop {
         tokio::select! {
             biased;
             _ = &mut shutdown => {
-                info!("shutdown signal received; copy-trading exiting");
+                info!(open_positions = positions.len(), "shutdown signal received");
                 return Ok(());
             }
             maybe_log = rx.recv() => {
@@ -112,9 +167,6 @@ fn build_filter(cfg: &AppConfig, whale: &str) -> Result<LogFilter> {
     let whale_topic = pad_address_to_topic(whale)?;
     Ok(LogFilter {
         address: exchanges,
-        // topic0 = OrderFilled selector
-        // topic1 = orderHash (any)
-        // topic2 = maker = whale
         topics: vec![
             Some(vec![topic0]),
             None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,14 @@ pub struct AppConfig {
     pub risk: RiskConfig,
     pub exchange: ExchangeConfig,
 
+    /// Market eligibility filter (allowlist + blocklist by category, tag, slug).
+    #[serde(default)]
+    pub filters: FiltersConfig,
+
+    /// Take-profit / stop-loss configuration.
+    #[serde(default)]
+    pub tp_sl: TpSlConfig,
+
     /// Loaded from `config.yaml`. Not serialised back out.
     #[serde(skip)]
     pub credentials: Credentials,
@@ -103,6 +111,83 @@ pub struct ExchangeConfig {
     pub domain_name: String,
     pub domain_version: String,
 }
+
+/// Market eligibility filter.
+///
+/// Behavior:
+/// 1. Block lists always win — anything matching is skipped.
+/// 2. If *any* allow list is non-empty, the market must match at least one
+///    allow rule for ANY of (slug / category / tag) to be eligible.
+/// 3. If all allow lists are empty, the bot falls back to allow-everything-
+///    minus-blocklist semantics (so users who haven't curated yet aren't
+///    stranded with zero trades).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FiltersConfig {
+    #[serde(default)]
+    pub slug_allow: Vec<String>,
+    #[serde(default)]
+    pub slug_block: Vec<String>,
+    #[serde(default)]
+    pub categories_allow: Vec<String>,
+    #[serde(default)]
+    pub categories_block: Vec<String>,
+    #[serde(default)]
+    pub tags_allow: Vec<String>,
+    #[serde(default)]
+    pub tags_block: Vec<String>,
+
+    /// Per-category cap on simultaneously open USD notional.
+    /// e.g. `{ "Politics": 500, "Sports": 300 }`.
+    #[serde(default)]
+    pub per_category_max_open_usd: std::collections::HashMap<String, f64>,
+
+    /// Per-tag cap on simultaneously open USD notional.
+    #[serde(default)]
+    pub per_tag_max_open_usd: std::collections::HashMap<String, f64>,
+}
+
+impl FiltersConfig {
+    /// True when at least one allow list is populated — strict allowlist mode.
+    pub fn is_strict(&self) -> bool {
+        !self.slug_allow.is_empty()
+            || !self.categories_allow.is_empty()
+            || !self.tags_allow.is_empty()
+    }
+}
+
+/// Take-profit / stop-loss config (percent of entry price).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TpSlConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default = "default_tp_pct")]
+    pub default_take_profit_pct: f64,
+    #[serde(default = "default_sl_pct")]
+    pub default_stop_loss_pct: f64,
+    #[serde(default)]
+    pub per_category_tp_pct: std::collections::HashMap<String, f64>,
+    #[serde(default)]
+    pub per_category_sl_pct: std::collections::HashMap<String, f64>,
+    #[serde(default = "default_monitor_secs")]
+    pub poll_interval_secs: u64,
+}
+
+impl Default for TpSlConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            default_take_profit_pct: 50.0,
+            default_stop_loss_pct: 30.0,
+            per_category_tp_pct: Default::default(),
+            per_category_sl_pct: Default::default(),
+            poll_interval_secs: 15,
+        }
+    }
+}
+
+fn default_tp_pct() -> f64 { 50.0 }
+fn default_sl_pct() -> f64 { 30.0 }
+fn default_monitor_secs() -> u64 { 15 }
 
 #[derive(Debug, Clone, Default)]
 pub struct Credentials {

--- a/src/service/eligibility.rs
+++ b/src/service/eligibility.rs
@@ -1,0 +1,148 @@
+//! Market eligibility filter.
+//!
+//! Decides whether the bot should consider copying a trade given the
+//! market's slug, category, and tags vs the configured allow/block lists.
+//!
+//! Behaviour matches the brief picked by the operator: strict allowlist
+//! when any `*_allow` list is populated, otherwise allow-everything-minus-
+//! blocklist. Blocklists always take precedence.
+
+use crate::config::FiltersConfig;
+use crate::service::market_cache::MarketInfo;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Eligibility {
+    Allowed,
+    Closed,
+    BlockedBySlug,
+    BlockedByCategory(String),
+    BlockedByTag(String),
+    NotInAllowlist,
+}
+
+pub fn check(filters: &FiltersConfig, market: &MarketInfo) -> Eligibility {
+    if market.closed {
+        return Eligibility::Closed;
+    }
+
+    // 1. Block lists always win.
+    if filters.slug_block.iter().any(|s| s == &market.slug) {
+        return Eligibility::BlockedBySlug;
+    }
+    if let Some(cat) = market.category.as_ref() {
+        if filters.categories_block.iter().any(|c| ci_eq(c, cat)) {
+            return Eligibility::BlockedByCategory(cat.clone());
+        }
+    }
+    if let Some(blocked) = market
+        .tags
+        .iter()
+        .find(|tag| filters.tags_block.iter().any(|b| ci_eq(b, tag)))
+    {
+        return Eligibility::BlockedByTag(blocked.clone());
+    }
+
+    // 2. If no allow lists are configured, accept everything that passed blocks.
+    if !filters.is_strict() {
+        return Eligibility::Allowed;
+    }
+
+    // 3. Strict allowlist — at least one allow rule must match across slug,
+    //    category, or tags. The slug allowlist is exact; cat/tag matching is
+    //    case-insensitive to forgive Gamma capitalisation drift.
+    let slug_hit = filters.slug_allow.iter().any(|s| s == &market.slug);
+    let cat_hit = market
+        .category
+        .as_ref()
+        .map(|cat| filters.categories_allow.iter().any(|c| ci_eq(c, cat)))
+        .unwrap_or(false);
+    let tag_hit = market
+        .tags
+        .iter()
+        .any(|tag| filters.tags_allow.iter().any(|t| ci_eq(t, tag)));
+
+    if slug_hit || cat_hit || tag_hit {
+        Eligibility::Allowed
+    } else {
+        Eligibility::NotInAllowlist
+    }
+}
+
+fn ci_eq(a: &str, b: &str) -> bool {
+    a.len() == b.len() && a.chars().zip(b.chars()).all(|(x, y)| {
+        x.to_ascii_lowercase() == y.to_ascii_lowercase()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn market(slug: &str, category: Option<&str>, tags: &[&str]) -> MarketInfo {
+        MarketInfo {
+            slug: slug.into(),
+            question: String::new(),
+            yes_token_id: "1".into(),
+            no_token_id: "2".into(),
+            category: category.map(String::from),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            closed: false,
+        }
+    }
+
+    #[test]
+    fn closed_market_always_blocked() {
+        let mut m = market("x", Some("Politics"), &[]);
+        m.closed = true;
+        let r = check(&FiltersConfig::default(), &m);
+        assert_eq!(r, Eligibility::Closed);
+    }
+
+    #[test]
+    fn default_filters_allow_everything() {
+        let r = check(&FiltersConfig::default(), &market("x", Some("Memes"), &[]));
+        assert_eq!(r, Eligibility::Allowed);
+    }
+
+    #[test]
+    fn category_block_wins_over_allow() {
+        let f = FiltersConfig {
+            categories_allow: vec!["Memes".into()],
+            categories_block: vec!["Memes".into()],
+            ..Default::default()
+        };
+        let r = check(&f, &market("x", Some("Memes"), &[]));
+        matches!(r, Eligibility::BlockedByCategory(_));
+    }
+
+    #[test]
+    fn strict_allowlist_rejects_unlisted_category() {
+        let f = FiltersConfig {
+            categories_allow: vec!["Politics".into()],
+            ..Default::default()
+        };
+        let r = check(&f, &market("x", Some("Crypto"), &[]));
+        assert_eq!(r, Eligibility::NotInAllowlist);
+    }
+
+    #[test]
+    fn strict_allowlist_admits_listed_category() {
+        let f = FiltersConfig {
+            categories_allow: vec!["politics".into()],
+            ..Default::default()
+        };
+        let r = check(&f, &market("x", Some("Politics"), &[]));
+        assert_eq!(r, Eligibility::Allowed);
+    }
+
+    #[test]
+    fn slug_allow_overrides_category_miss() {
+        let f = FiltersConfig {
+            categories_allow: vec!["Politics".into()],
+            slug_allow: vec!["my-fav-market".into()],
+            ..Default::default()
+        };
+        let r = check(&f, &market("my-fav-market", Some("Crypto"), &[]));
+        assert_eq!(r, Eligibility::Allowed);
+    }
+}

--- a/src/service/market_cache.rs
+++ b/src/service/market_cache.rs
@@ -19,14 +19,26 @@ pub struct MarketInfo {
     pub question: String,
     pub yes_token_id: String,
     pub no_token_id: String,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
     pub closed: bool,
+}
+
+impl MarketInfo {
+    /// Returns true if this market metadata describes the given outcome token.
+    pub fn contains_token(&self, token_id: &str) -> bool {
+        self.yes_token_id == token_id || self.no_token_id == token_id
+    }
 }
 
 #[derive(Debug)]
 pub struct MarketCache {
     http: Client,
     gamma_base: String,
+    /// Slug → (info, when fetched)
     entries: RwLock<HashMap<String, (MarketInfo, Instant)>>,
+    /// Token-id → slug, so token-id lookups can hit the slug cache.
+    token_index: RwLock<HashMap<String, String>>,
     ttl: Duration,
 }
 
@@ -36,6 +48,7 @@ impl MarketCache {
             http,
             gamma_base: gamma_base.into(),
             entries: RwLock::new(HashMap::new()),
+            token_index: RwLock::new(HashMap::new()),
             ttl: DEFAULT_TTL,
         })
     }
@@ -45,7 +58,20 @@ impl MarketCache {
             return Ok(info);
         }
         let info = self.fetch_by_slug(slug).await?;
-        self.insert(slug.to_string(), info.clone());
+        self.insert(info.clone());
+        Ok(info)
+    }
+
+    /// Resolve a CLOB token id (either YES or NO leg) to its full market info.
+    /// First consults the in-memory token-index; on miss, queries Gamma.
+    pub async fn by_token_id(&self, token_id: &str) -> Result<MarketInfo> {
+        if let Some(slug) = self.token_index.read().get(token_id).cloned() {
+            if let Some(info) = self.peek(&slug) {
+                return Ok(info);
+            }
+        }
+        let info = self.fetch_by_token(token_id).await?;
+        self.insert(info.clone());
         Ok(info)
     }
 
@@ -60,31 +86,53 @@ impl MarketCache {
         })
     }
 
-    fn insert(&self, slug: String, info: MarketInfo) {
-        let mut g = self.entries.write();
-        g.insert(slug, (info, Instant::now()));
+    fn insert(&self, info: MarketInfo) {
+        let mut e = self.entries.write();
+        let mut t = self.token_index.write();
+        t.insert(info.yes_token_id.clone(), info.slug.clone());
+        t.insert(info.no_token_id.clone(), info.slug.clone());
+        e.insert(info.slug.clone(), (info, Instant::now()));
     }
 
     async fn fetch_by_slug(&self, slug: &str) -> Result<MarketInfo> {
         let url = format!("{}/markets?slug={}", self.gamma_base, slug);
+        let body = self.fetch_markets_url(&url).await?;
+        let m = body
+            .iter()
+            .find(|m| m.get("slug").and_then(|v| v.as_str()) == Some(slug))
+            .ok_or_else(|| anyhow!("slug {slug} not found in gamma response"))?;
+        parse_market(m)
+    }
+
+    async fn fetch_by_token(&self, token_id: &str) -> Result<MarketInfo> {
+        // Gamma accepts ?clob_token_ids=<id> on the markets endpoint.
+        let url = format!("{}/markets?clob_token_ids={}", self.gamma_base, token_id);
+        let body = self.fetch_markets_url(&url).await?;
+        let m = body
+            .iter()
+            .find(|m| {
+                if let Ok(parsed) = parse_market(m) {
+                    parsed.contains_token(token_id)
+                } else {
+                    false
+                }
+            })
+            .ok_or_else(|| anyhow!("token_id {token_id} not resolved by gamma"))?;
+        parse_market(m)
+    }
+
+    async fn fetch_markets_url(&self, url: &str) -> Result<Vec<serde_json::Value>> {
         let resp = self
             .http
-            .get(&url)
+            .get(url)
             .send()
             .await?
             .error_for_status()?
             .json::<serde_json::Value>()
             .await?;
-
-        let markets = resp
-            .as_array()
-            .ok_or_else(|| anyhow!("gamma /markets returned non-array"))?;
-        let m = markets
-            .iter()
-            .find(|m| m.get("slug").and_then(|v| v.as_str()) == Some(slug))
-            .ok_or_else(|| anyhow!("slug {slug} not found in gamma response"))?;
-
-        parse_market(m)
+        resp.as_array()
+            .cloned()
+            .ok_or_else(|| anyhow!("gamma /markets returned non-array for {url}"))
     }
 }
 
@@ -118,11 +166,37 @@ fn parse_market(m: &serde_json::Value) -> Result<MarketInfo> {
         return Err(anyhow!("expected 2 clob token ids, got {}", tokens.len()));
     }
 
+    let category = m
+        .get("category")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // `tags` is sometimes an array of strings, sometimes an array of objects
+    // with `label` / `slug` fields depending on Gamma version. Read defensively.
+    let tags = match m.get("tags") {
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|t| {
+                if let Some(s) = t.as_str() {
+                    Some(s.to_string())
+                } else {
+                    t.get("label")
+                        .and_then(|v| v.as_str())
+                        .or_else(|| t.get("slug").and_then(|v| v.as_str()))
+                        .map(|s| s.to_string())
+                }
+            })
+            .collect(),
+        _ => Vec::new(),
+    };
+
     Ok(MarketInfo {
         slug,
         question,
         yes_token_id: tokens[0].clone(),
         no_token_id: tokens[1].clone(),
+        category,
+        tags,
         closed,
     })
 }

--- a/src/service/midprice.rs
+++ b/src/service/midprice.rs
@@ -1,0 +1,52 @@
+//! Midprice quote source for the position monitor.
+//!
+//! Polymarket exposes a `/midpoint?token_id=X` endpoint that returns the
+//! mid between best bid and best ask for a single outcome token. Cheap and
+//! exactly what TP/SL polling needs.
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+#[async_trait]
+pub trait MidpriceSource: Send + Sync {
+    async fn midprice(&self, token_id: &str) -> Result<f64>;
+}
+
+pub struct ClobMidpriceSource {
+    http: Client,
+    clob_base: String,
+}
+
+impl ClobMidpriceSource {
+    pub fn new(http: Client, clob_base: impl Into<String>) -> Self {
+        Self {
+            http,
+            clob_base: clob_base.into(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct MidpointResponse {
+    mid: String,
+}
+
+#[async_trait]
+impl MidpriceSource for ClobMidpriceSource {
+    async fn midprice(&self, token_id: &str) -> Result<f64> {
+        let url = format!("{}/midpoint?token_id={}", self.clob_base, token_id);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<MidpointResponse>()
+            .await?;
+        resp.mid
+            .parse::<f64>()
+            .map_err(|e| anyhow!("midpoint not a float: {e}"))
+    }
+}

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,17 +1,25 @@
 //! Shared services consumed by every bot:
 //!
-//! - [`strategy`]   — copy-sizing strategies (percentage / fixed / adaptive)
-//! - [`risk_guard`] — circuit breaker + depth check
-//! - [`market_cache`] — slug → CLOB token-id resolution
-//! - [`onchain`]    — Polygon WebSocket subscription
-//! - [`parse`]      — ABI log decoding for Polymarket exchange events
-//! - [`clob`]       — Polymarket CLOB v2 client: EIP-712 signing, order POST
-//! - [`order_executor`] — applies sizing, risk, and dispatches to the CLOB
+//! - [`strategy`]         — copy-sizing strategies (percentage / fixed / adaptive)
+//! - [`risk_guard`]       — circuit breaker + depth check
+//! - [`market_cache`]     — slug ↔ CLOB token-id ↔ category/tags resolution
+//! - [`onchain`]          — Polygon WebSocket subscription
+//! - [`parse`]            — ABI log decoding for Polymarket exchange events
+//! - [`clob`]             — Polymarket CLOB v2 client: EIP-712 signing, order POST
+//! - [`order_executor`]   — applies sizing, eligibility, exposure, risk, and dispatch
+//! - [`eligibility`]      — allowlist/blocklist filter for slugs, categories, tags
+//! - [`position_store`]   — open-position tracking + exposure totals
+//! - [`midprice`]         — `/midpoint` HTTP client (trait, swappable)
+//! - [`position_monitor`] — TP/SL polling loop, posts exit FAKs through the CLOB
 
 pub mod clob;
+pub mod eligibility;
 pub mod market_cache;
+pub mod midprice;
 pub mod onchain;
 pub mod order_executor;
 pub mod parse;
+pub mod position_monitor;
+pub mod position_store;
 pub mod risk_guard;
 pub mod strategy;

--- a/src/service/order_executor.rs
+++ b/src/service/order_executor.rs
@@ -1,24 +1,31 @@
-//! High-level execution surface: glue between sizing → risk → signing → POST.
+//! High-level execution surface: glue between metadata → eligibility →
+//! sizing → exposure → risk → signing → POST → position recording.
 //!
 //! Every bot routes its decided trades through [`OrderExecutor::execute`].
-//! Safety flags are checked here, so individual bots never accidentally bypass
-//! `enable_trading` or `mock_trading`.
+//! Safety flags are checked here, so individual bots never accidentally
+//! bypass `enable_trading` or `mock_trading`.
 
 use std::sync::Arc;
 
 use crate::config::AppConfig;
 use crate::models::{OrderType, PlannedOrder, Side, WhaleTrade};
 use crate::service::clob::{ClobClient, SignedOrder};
+use crate::service::eligibility::{self, Eligibility};
+use crate::service::market_cache::{MarketCache, MarketInfo};
+use crate::service::position_store::{OpenPosition, PositionStore};
 use crate::service::risk_guard::{BlockReason, RiskCheck, RiskGuard};
 use crate::service::strategy;
 use crate::utils;
 use anyhow::Result;
+use chrono::Utc;
 use tracing::{info, warn};
 
 pub struct OrderExecutor {
     cfg: AppConfig,
-    clob: Option<ClobClient>,
+    clob: Option<Arc<ClobClient>>,
     risk: Arc<RiskGuard>,
+    markets: Arc<MarketCache>,
+    positions: Arc<PositionStore>,
 }
 
 #[derive(Debug, Clone)]
@@ -31,42 +38,111 @@ pub enum ExecutionOutcome {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub enum SkipReason {
     BelowSizing,
+    MarketMetadataUnavailable,
+    Ineligible(Eligibility),
+    ExposureCategoryCap { category: String, cap: f64, current: f64, want: f64 },
+    ExposureTagCap { tag: String, cap: f64, current: f64, want: f64 },
     RiskBlocked(BlockReason),
     TradingDisabled,
+    AlreadyOpen,
+    /// Whale closed/reduced their position. We delegate exits to the TP/SL
+    /// monitor rather than mirroring the unwind, so this is a no-op by design.
+    WhaleExitIgnored,
 }
 
 impl OrderExecutor {
-    pub fn new(cfg: AppConfig, risk: Arc<RiskGuard>) -> Result<Self> {
-        // CLOB client requires a valid private key. In mock mode we may not
-        // have one — return a stub-less executor instead of failing the boot.
+    pub fn new(
+        cfg: AppConfig,
+        risk: Arc<RiskGuard>,
+        markets: Arc<MarketCache>,
+        positions: Arc<PositionStore>,
+    ) -> Result<Self> {
         let clob = match ClobClient::new(&cfg) {
-            Ok(c) => Some(c),
+            Ok(c) => Some(Arc::new(c)),
             Err(e) if cfg.bot.mock_trading || !cfg.bot.enable_trading => {
                 warn!(error = ?e, "CLOB client not initialised; dry-run only");
                 None
             }
             Err(e) => return Err(e),
         };
-        Ok(Self { cfg, clob, risk })
+        Ok(Self {
+            cfg,
+            clob,
+            risk,
+            markets,
+            positions,
+        })
     }
 
-    /// Apply sizing + risk + signing for a single whale trade.
+    /// Return the underlying CLOB client (for the position monitor's exit path).
+    pub fn clob(&self) -> Option<Arc<ClobClient>> {
+        self.clob.as_ref().cloned()
+    }
+
+    pub fn positions(&self) -> Arc<PositionStore> {
+        Arc::clone(&self.positions)
+    }
+
     pub async fn execute(&self, trade: &WhaleTrade) -> Result<ExecutionOutcome> {
+        // 0a. Whale sells are not mirrored — TP/SL is the configured exit path.
+        if trade.side == Side::Sell {
+            return Ok(ExecutionOutcome::Skipped(SkipReason::WhaleExitIgnored));
+        }
+        // 0b. Don't pyramid into a market we're already long.
+        if self.positions.get(&trade.token_id).is_some() {
+            return Ok(ExecutionOutcome::Skipped(SkipReason::AlreadyOpen));
+        }
+
+        // 1. Resolve market metadata for category/tags/closed lookup.
+        let market = match self.markets.by_token_id(&trade.token_id).await {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(token = %trade.token_id, error = ?e, "market metadata lookup failed");
+                return Ok(ExecutionOutcome::Skipped(
+                    SkipReason::MarketMetadataUnavailable,
+                ));
+            }
+        };
+
+        // 2. Eligibility (allowlist / blocklist / closed).
+        let eligibility = eligibility::check(&self.cfg.filters, &market);
+        if eligibility != Eligibility::Allowed {
+            info!(
+                slug = %market.slug,
+                category = ?market.category,
+                ?eligibility,
+                "market not eligible"
+            );
+            return Ok(ExecutionOutcome::Skipped(SkipReason::Ineligible(
+                eligibility,
+            )));
+        }
+
+        // 3. Sizing.
         let sizing = strategy::size_for_trade(&self.cfg.strategy, trade);
         if let Some(r) = sizing.skipped {
             info!(?r, "sizing skipped trade");
             return Ok(ExecutionOutcome::Skipped(SkipReason::BelowSizing));
         }
 
+        // 4. Per-category / per-tag exposure caps (entries only).
+        if trade.side == Side::Buy {
+            if let Some(skip) = self.check_exposure(&market, sizing.copy_usd) {
+                info!(?skip, "exposure cap blocked entry");
+                return Ok(ExecutionOutcome::Skipped(skip));
+            }
+        }
+
+        // 5. Risk guard.
         match self.risk.check_fast(trade) {
             RiskCheck::Allow => {}
             RiskCheck::FetchBook => {
-                // The book fetch happens at the caller; for now we proceed,
-                // mirroring the brief's "book fetch failure trips the breaker".
-                // A real bot would call `MarketCache + orderbook fetcher` here.
+                // Caller (or a follow-up) should pull the book and call
+                // `risk.check_with_book`. For now we proceed but flag the
+                // pre-trade book fetch as the next integration point.
             }
             RiskCheck::Block(reason) => {
                 warn!(?reason, "risk guard blocked trade");
@@ -74,10 +150,10 @@ impl OrderExecutor {
             }
         }
 
+        // 6. Build the order.
         let limit_price = limit_price_for(trade, &self.cfg);
         let shares = utils::usd_to_shares(sizing.copy_usd, limit_price);
         let order_type = order_type_for(trade.side);
-
         let planned = PlannedOrder {
             venue: trade.venue,
             token_id: trade.token_id.clone(),
@@ -93,26 +169,121 @@ impl OrderExecutor {
             return Ok(ExecutionOutcome::Skipped(SkipReason::TradingDisabled));
         };
 
+        // 7. Sign.
         let signed = clob
             .build_signed_order(&planned, order_type, self.cfg.trading.order_expiration_secs)
             .await?;
 
+        // 8. Dispatch (or dry-run).
         if !self.cfg.live_trading_allowed() {
             info!(
-                token_id = %planned.token_id,
+                token = %planned.token_id,
                 side = ?planned.side,
                 shares = planned.shares,
                 price = planned.limit_price,
                 "dry-run: signed order built but not submitted"
             );
+            // Even in dry-run, record the position so the monitor exercises
+            // the TP/SL path against real midprices.
+            self.record_open(&market, &planned);
             return Ok(ExecutionOutcome::DryRun(signed));
         }
 
         let resp = clob.post_order(signed.clone(), order_type).await?;
+        self.record_open(&market, &planned);
         Ok(ExecutionOutcome::Submitted {
             order_id: resp.order_id,
             signed,
         })
+    }
+
+    fn check_exposure(&self, market: &MarketInfo, want_usd: f64) -> Option<SkipReason> {
+        let filters = &self.cfg.filters;
+        if let Some(cat) = market.category.as_ref() {
+            if let Some(&cap) = filters
+                .per_category_max_open_usd
+                .iter()
+                .find(|(k, _)| ci_eq(k, cat))
+                .map(|(_, v)| v)
+            {
+                let current = self.positions.open_usd_by_category(cat);
+                if current + want_usd > cap {
+                    return Some(SkipReason::ExposureCategoryCap {
+                        category: cat.clone(),
+                        cap,
+                        current,
+                        want: want_usd,
+                    });
+                }
+            }
+        }
+        for tag in &market.tags {
+            if let Some(&cap) = filters
+                .per_tag_max_open_usd
+                .iter()
+                .find(|(k, _)| ci_eq(k, tag))
+                .map(|(_, v)| v)
+            {
+                let current = self.positions.open_usd_by_tag(tag);
+                if current + want_usd > cap {
+                    return Some(SkipReason::ExposureTagCap {
+                        tag: tag.clone(),
+                        cap,
+                        current,
+                        want: want_usd,
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    fn record_open(&self, market: &MarketInfo, planned: &PlannedOrder) {
+        // Only entries open positions; exits remove them in the monitor.
+        if planned.side != Side::Buy {
+            return;
+        }
+        let (tp_pct, sl_pct) = self.tp_sl_for(market);
+        let pos = OpenPosition {
+            token_id: planned.token_id.clone(),
+            slug: market.slug.clone(),
+            category: market.category.clone(),
+            tags: market.tags.clone(),
+            side: planned.side,
+            entry_price: planned.limit_price,
+            shares: planned.shares,
+            usd_notional: planned.usd_notional,
+            take_profit_pct: tp_pct,
+            stop_loss_pct: sl_pct,
+            opened_at: Utc::now(),
+        };
+        self.positions.open(pos);
+    }
+
+    fn tp_sl_for(&self, market: &MarketInfo) -> (f64, f64) {
+        let tp_default = self.cfg.tp_sl.default_take_profit_pct;
+        let sl_default = self.cfg.tp_sl.default_stop_loss_pct;
+        if let Some(cat) = market.category.as_ref() {
+            let tp = self
+                .cfg
+                .tp_sl
+                .per_category_tp_pct
+                .iter()
+                .find(|(k, _)| ci_eq(k, cat))
+                .map(|(_, v)| *v)
+                .unwrap_or(tp_default);
+            let sl = self
+                .cfg
+                .tp_sl
+                .per_category_sl_pct
+                .iter()
+                .find(|(k, _)| ci_eq(k, cat))
+                .map(|(_, v)| *v)
+                .unwrap_or(sl_default);
+            (tp, sl)
+        } else {
+            (tp_default, sl_default)
+        }
     }
 }
 
@@ -127,9 +298,13 @@ fn limit_price_for(trade: &WhaleTrade, cfg: &AppConfig) -> f64 {
 
 fn order_type_for(side: Side) -> OrderType {
     match side {
-        // Buys chase aggressively per the brief — FAK semantics.
         Side::Buy => OrderType::Fak,
-        // Sells unwind with time-bounded limits.
         Side::Sell => OrderType::Gtd,
     }
+}
+
+fn ci_eq(a: &str, b: &str) -> bool {
+    a.len() == b.len() && a.chars().zip(b.chars()).all(|(x, y)| {
+        x.to_ascii_lowercase() == y.to_ascii_lowercase()
+    })
 }

--- a/src/service/position_monitor.rs
+++ b/src/service/position_monitor.rs
@@ -1,0 +1,208 @@
+//! Take-profit / stop-loss monitor.
+//!
+//! Periodically polls the midprice of every open position. When the P&L
+//! relative to the recorded entry crosses the take-profit or stop-loss
+//! threshold, the monitor synthesises an exit `PlannedOrder` and posts it
+//! through the existing executor — same signing path, same risk gates.
+
+use crate::config::TpSlConfig;
+use crate::models::{OrderType, PlannedOrder, Side, VenueId};
+use crate::service::clob::ClobClient;
+use crate::service::midprice::MidpriceSource;
+use crate::service::position_store::{OpenPosition, PositionStore};
+use crate::utils;
+use anyhow::Result;
+use std::sync::Arc;
+use tokio::time::{interval, Duration};
+use tracing::{debug, error, info, warn};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitReason {
+    TakeProfit,
+    StopLoss,
+}
+
+pub fn check_exit(pos: &OpenPosition, midprice: f64) -> Option<ExitReason> {
+    let pnl = pos.pnl_pct(midprice);
+    if pnl >= pos.take_profit_pct {
+        Some(ExitReason::TakeProfit)
+    } else if pnl <= -pos.stop_loss_pct {
+        Some(ExitReason::StopLoss)
+    } else {
+        None
+    }
+}
+
+/// Spawns the monitor task. The handle lets the caller observe shutdown
+/// independently of the main bot loop.
+pub fn spawn(
+    cfg: TpSlConfig,
+    positions: Arc<PositionStore>,
+    clob: Arc<ClobClient>,
+    midprice: Arc<dyn MidpriceSource>,
+    live_trading: bool,
+    price_buffer: f64,
+    order_expiration_secs: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if !cfg.enabled {
+            info!("TP/SL monitor disabled in config — exiting task");
+            return;
+        }
+        let mut ticker = interval(Duration::from_secs(cfg.poll_interval_secs.max(1)));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            let snapshot = positions.snapshot();
+            for pos in snapshot {
+                if let Err(e) = monitor_once(
+                    &pos,
+                    &positions,
+                    clob.as_ref(),
+                    midprice.as_ref(),
+                    live_trading,
+                    price_buffer,
+                    order_expiration_secs,
+                )
+                .await
+                {
+                    error!(
+                        token = %pos.token_id,
+                        error = ?e,
+                        "tp/sl tick failed for position"
+                    );
+                }
+            }
+        }
+    })
+}
+
+async fn monitor_once(
+    pos: &OpenPosition,
+    positions: &PositionStore,
+    clob: &ClobClient,
+    midprice: &dyn MidpriceSource,
+    live_trading: bool,
+    price_buffer: f64,
+    order_expiration_secs: u64,
+) -> Result<()> {
+    let mp = midprice.midprice(&pos.token_id).await?;
+    let pnl = pos.pnl_pct(mp);
+    debug!(
+        token = %pos.token_id,
+        mid = mp,
+        entry = pos.entry_price,
+        pnl_pct = pnl,
+        "tp/sl tick"
+    );
+
+    let Some(reason) = check_exit(pos, mp) else {
+        return Ok(());
+    };
+
+    info!(
+        token = %pos.token_id,
+        slug = %pos.slug,
+        ?reason,
+        pnl_pct = pnl,
+        midprice = mp,
+        "TP/SL triggered — submitting exit"
+    );
+
+    let exit_side = pos.side.flip();
+    let limit_price = match exit_side {
+        // Selling out — accept a buffer below the mid to make sure we fill.
+        Side::Sell => utils::clamp_price(mp - price_buffer),
+        // Buying to cover — pay up by the buffer.
+        Side::Buy => utils::clamp_price(mp + price_buffer),
+    };
+
+    let planned = PlannedOrder {
+        venue: VenueId::Polymarket,
+        token_id: pos.token_id.clone(),
+        side: exit_side,
+        shares: pos.shares,
+        limit_price,
+        usd_notional: pos.shares * limit_price,
+        order_type: OrderType::Fak,
+        source_trade_hash: None,
+    };
+
+    let signed = clob
+        .build_signed_order(&planned, OrderType::Fak, order_expiration_secs)
+        .await?;
+
+    if live_trading {
+        match clob.post_order(signed.clone(), OrderType::Fak).await {
+            Ok(resp) => {
+                info!(
+                    order_id = ?resp.order_id,
+                    token = %pos.token_id,
+                    "exit order submitted"
+                );
+                positions.close(&pos.token_id);
+            }
+            Err(e) => {
+                warn!(error = ?e, token = %pos.token_id, "exit POST failed; will retry next tick");
+            }
+        }
+    } else {
+        info!(
+            token = %pos.token_id,
+            shares = planned.shares,
+            limit = planned.limit_price,
+            "dry-run exit signed (not submitted) — closing position locally"
+        );
+        positions.close(&pos.token_id);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn pos(entry: f64, tp: f64, sl: f64, side: Side) -> OpenPosition {
+        OpenPosition {
+            token_id: "t".into(),
+            slug: "s".into(),
+            category: None,
+            tags: vec![],
+            side,
+            entry_price: entry,
+            shares: 100.0,
+            usd_notional: 100.0 * entry,
+            take_profit_pct: tp,
+            stop_loss_pct: sl,
+            opened_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn take_profit_triggers() {
+        let p = pos(0.50, 30.0, 20.0, Side::Buy);
+        assert_eq!(check_exit(&p, 0.70), Some(ExitReason::TakeProfit));
+    }
+
+    #[test]
+    fn stop_loss_triggers() {
+        let p = pos(0.50, 30.0, 20.0, Side::Buy);
+        assert_eq!(check_exit(&p, 0.39), Some(ExitReason::StopLoss));
+    }
+
+    #[test]
+    fn flat_range_does_not_trigger() {
+        let p = pos(0.50, 30.0, 20.0, Side::Buy);
+        assert_eq!(check_exit(&p, 0.55), None);
+    }
+
+    #[test]
+    fn sell_inverted_pnl_logic() {
+        let p = pos(0.50, 30.0, 20.0, Side::Sell);
+        // Price went DOWN — short position is in profit.
+        assert_eq!(check_exit(&p, 0.30), Some(ExitReason::TakeProfit));
+        // Price went UP — short position hit stop.
+        assert_eq!(check_exit(&p, 0.65), Some(ExitReason::StopLoss));
+    }
+}

--- a/src/service/position_store.rs
+++ b/src/service/position_store.rs
@@ -1,0 +1,165 @@
+//! Open-position tracking + per-category / per-tag exposure accounting.
+//!
+//! Single source of truth for "what are we currently long/short?". The order
+//! executor inserts on successful entries; the position monitor reads
+//! snapshots and removes on exit. Exposure totals are derived on demand —
+//! cheap because the working set is bounded by `max_open_positions`-ish.
+
+use crate::models::Side;
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct OpenPosition {
+    pub token_id: String,
+    pub slug: String,
+    pub category: Option<String>,
+    pub tags: Vec<String>,
+    pub side: Side,
+    pub entry_price: f64,
+    pub shares: f64,
+    pub usd_notional: f64,
+    pub take_profit_pct: f64,
+    pub stop_loss_pct: f64,
+    pub opened_at: DateTime<Utc>,
+}
+
+impl OpenPosition {
+    /// Current unrealised P&L percentage given a midprice quote.
+    ///
+    /// For BUY entries (long the outcome), gain = +(midprice - entry) / entry.
+    /// For SELL entries (rare on Polymarket, short the outcome), gain is
+    /// inverted.
+    pub fn pnl_pct(&self, midprice: f64) -> f64 {
+        if self.entry_price <= 0.0 {
+            return 0.0;
+        }
+        let raw = (midprice - self.entry_price) / self.entry_price * 100.0;
+        match self.side {
+            Side::Buy => raw,
+            Side::Sell => -raw,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct PositionStore {
+    inner: RwLock<HashMap<String, OpenPosition>>,
+}
+
+impl PositionStore {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn open(&self, pos: OpenPosition) {
+        self.inner.write().insert(pos.token_id.clone(), pos);
+    }
+
+    pub fn close(&self, token_id: &str) -> Option<OpenPosition> {
+        self.inner.write().remove(token_id)
+    }
+
+    pub fn get(&self, token_id: &str) -> Option<OpenPosition> {
+        self.inner.read().get(token_id).cloned()
+    }
+
+    pub fn snapshot(&self) -> Vec<OpenPosition> {
+        self.inner.read().values().cloned().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+
+    pub fn open_usd_by_category(&self, category: &str) -> f64 {
+        self.inner
+            .read()
+            .values()
+            .filter(|p| {
+                p.category
+                    .as_ref()
+                    .map(|c| ci_eq(c, category))
+                    .unwrap_or(false)
+            })
+            .map(|p| p.usd_notional)
+            .sum()
+    }
+
+    pub fn open_usd_by_tag(&self, tag: &str) -> f64 {
+        self.inner
+            .read()
+            .values()
+            .filter(|p| p.tags.iter().any(|t| ci_eq(t, tag)))
+            .map(|p| p.usd_notional)
+            .sum()
+    }
+}
+
+fn ci_eq(a: &str, b: &str) -> bool {
+    a.len() == b.len() && a.chars().zip(b.chars()).all(|(x, y)| {
+        x.to_ascii_lowercase() == y.to_ascii_lowercase()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pos(slug: &str, cat: &str, tags: &[&str], usd: f64) -> OpenPosition {
+        OpenPosition {
+            token_id: format!("tok-{slug}"),
+            slug: slug.into(),
+            category: Some(cat.into()),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+            side: Side::Buy,
+            entry_price: 0.50,
+            shares: usd * 2.0,
+            usd_notional: usd,
+            take_profit_pct: 50.0,
+            stop_loss_pct: 30.0,
+            opened_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn category_exposure_sums_only_same_category() {
+        let s = PositionStore::default();
+        s.open(pos("a", "Politics", &[], 100.0));
+        s.open(pos("b", "Politics", &[], 50.0));
+        s.open(pos("c", "Crypto", &[], 200.0));
+        assert_eq!(s.open_usd_by_category("Politics"), 150.0);
+        assert_eq!(s.open_usd_by_category("crypto"), 200.0);
+    }
+
+    #[test]
+    fn tag_exposure_sums_across_multiple_tags() {
+        let s = PositionStore::default();
+        s.open(pos("a", "Politics", &["election2024", "us"], 100.0));
+        s.open(pos("b", "Politics", &["us"], 50.0));
+        assert_eq!(s.open_usd_by_tag("us"), 150.0);
+        assert_eq!(s.open_usd_by_tag("election2024"), 100.0);
+    }
+
+    #[test]
+    fn pnl_pct_buy_long_direction() {
+        let mut p = pos("a", "X", &[], 100.0);
+        p.entry_price = 0.50;
+        assert!((p.pnl_pct(0.75) - 50.0).abs() < 1e-9);
+        assert!((p.pnl_pct(0.25) + 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pnl_pct_sell_short_direction() {
+        let mut p = pos("a", "X", &[], 100.0);
+        p.side = Side::Sell;
+        p.entry_price = 0.50;
+        assert!((p.pnl_pct(0.25) - 50.0).abs() < 1e-9);
+    }
+}


### PR DESCRIPTION
Now runs in this order, each step short-circuits cleanly:

Whale SELL? → skip (WhaleExitIgnored) — exits are TP/SL's job, not the whale's
Already open? → skip (AlreadyOpen) — no pyramiding
Resolve market via MarketCache::by_token_id (Gamma ?clob_token_ids=…)
Eligibility → strict allowlist, block lists always win
Sizing (PERCENTAGE / FIXED / ADAPTIVE)
Exposure caps — per-category and per-tag, rejects if current + want > cap
Risk guard (existing circuit breaker)
Sign + post
Record open position — feeds the TP/SL monitor